### PR TITLE
SelectMenuBuilderを最新版のStringSelectMenueBuilderに書き換え

### DIFF
--- a/botmain.js
+++ b/botmain.js
@@ -1,4 +1,4 @@
-const { Client, GatewayIntentBits, Partials, Collection, EmbedBuilder, SlashCommandBuilder, Events,Message,ActionRowBuilder,SelectMenuBuilder} = require('discord.js');
+const { Client, GatewayIntentBits, Partials, Collection, EmbedBuilder, SlashCommandBuilder, Events,Message,ActionRowBuilder,StringSelectMenuBuilder} = require('discord.js');
 const config = require('./environmentConfig')
 let ccconfig=require("./CCConfig.json");
 const timetableBuilder  = require('./timetable/timetableUtils');
@@ -61,7 +61,7 @@ client.on("interactionCreate", async (interaction) => {
 //SelectMenu受け取り
 client.on(Events.InteractionCreate, async interaction =>
 {
-    if (!interaction.isSelectMenu ()) return;
+    if (!interaction.isStringSelectMenu()) return;
 
     // /createchanでのカテゴリ選択の受け取り
     if (interaction.customId === "selectCat")
@@ -98,7 +98,7 @@ client.on(Events.InteractionCreate, async interaction =>
             {
                 const mkRole=new ActionRowBuilder()
                     .addComponents(
-                        new SelectMenuBuilder()
+                        new StringSelectMenuBuilder()
                             .setCustomId("mkRole")
                             .addOptions
                             (

--- a/commands/createchan.js
+++ b/commands/createchan.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder,ActionRowBuilder,SelectMenuBuilder}=require("discord.js");
+const { SlashCommandBuilder,ActionRowBuilder,StringSelectMenuBuilder}=require("discord.js");
 let ccconfig=require("../CCConfig.json");
 const fs=require("fs");
 
@@ -26,7 +26,7 @@ module.exports=
                 //カテゴリ選択用SelectMenu作成
                 const selectCategory=new ActionRowBuilder()
                     .addComponents(
-                        new SelectMenuBuilder()
+                        new StringSelectMenuBuilder()
                             .setPlaceholder("カテゴリを選択")
                             .setCustomId("selectCat")
                             .addOptions(
@@ -151,7 +151,7 @@ module.exports=
                 let DCR= interactionCopy.options.getString("チャンネルとロールの削除");
                 const selectCategory=new ActionRowBuilder()
                     .addComponents(
-                        new SelectMenuBuilder()
+                        new StringSelectMenuBuilder()
                             .setPlaceholder("カテゴリを選択")
                             .setCustomId("remCat")
                             .addOptions(


### PR DESCRIPTION
Discord.jsのバージョンアップに伴い、過去のSelectMenueBuilderがサポート対象されなかったため、
コードを変更した。